### PR TITLE
Enhancing Windows Tests on phpUnit - Sel 3 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "php-webdriver/webdriver": "1.14.0"
   },
   "scripts": {
-    "local": "CONFIG_FILE=config/test.conf.json TEST_FILE=tests/LocalTest.php /usr/bin/env php lib/runner.php",
-    "test": "CONFIG_FILE=config/test.conf.json TEST_FILE=tests/Test.php /usr/bin/env php lib/runner.php"
+    "local": "php triggertest.php LocalTest.php",
+    "test": "php triggertest.php Test.php"
   },
   "autoload": {
     "classmap": ["lib/"]

--- a/lib/BrowserStackTest.php
+++ b/lib/BrowserStackTest.php
@@ -13,7 +13,7 @@ class BrowserStackTest extends PHPUnit\Framework\TestCase {
         $task_id = getenv('TASK_ID') ? getenv('TASK_ID') : 0;
 
         $url = "https://{$GLOBALS['BROWSERSTACK_USERNAME']}:{$GLOBALS['BROWSERSTACK_ACCESS_KEY']}@hub.browserstack.com/wd/hub";
-        $caps = $CONFIG['capabilities'][$task_id];
+        $caps = $CONFIG['capabilities'][(int)$task_id];
 
         self::$driver = RemoteWebDriver::create($url, $caps);
     }

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -13,8 +13,10 @@ if (!$test_file) {
 
 try {
     // the following code starts local binary, comment out if local testing not needed
-    $bs_local_args = array("key" => $GLOBALS['BROWSERSTACK_ACCESS_KEY']);
+    // Local binary started with additional args "logfile" => "logs.txt", "v" => true to get the local not started logs for debugging. Please remove them if not needed and cleanup logs if becoming huge.
+    $bs_local_args = array("key" => $GLOBALS['BROWSERSTACK_ACCESS_KEY'], "logfile" => "logs.txt", "v" => true);
     $bs_local = new BrowserStack\Local();
+    $currentOS = strtoupper(substr(PHP_OS, 0, 3));
     print("\nStarting Local Binary...\n");
     $bs_local->start($bs_local_args);
     if ($bs_local->isRunning()) {
@@ -22,6 +24,9 @@ try {
     }
     foreach ($CONFIG['capabilities'] as $key => $value) {
         $cmd = "TASK_ID=$key vendor/bin/phpunit $test_file 2>&1\n";
+        if ($currentOS == 'WIN') {
+            $cmd = "set TASK_ID=$key && vendor\bin\phpunit $test_file 2>&1\n";
+        }
         print_r($cmd);
     
         $procs[$key] = popen($cmd, "r");
@@ -34,6 +39,7 @@ try {
     }
 } catch (Exception $e) {
     echo $e->getMessage();
+    echo "Exception Trace:\n" . $e->getTraceAsString() . "\n";
 } finally {
     if($bs_local) {
         print("\nStopping local binary..\n");

--- a/triggertest.php
+++ b/triggertest.php
@@ -1,0 +1,11 @@
+<?php
+// Check if an argument is provided for config_file
+$testFileArg = $argv[1] ?? 'Test.php';
+$testFile = "tests" . DIRECTORY_SEPARATOR . $testFileArg;
+$configFile = "config" . DIRECTORY_SEPARATOR . "test.conf.json";
+putenv("TEST_FILE=$testFile");
+putenv("CONFIG_FILE=$configFile");
+// Execute the PHP script with the dynamically retrieved value
+require 'lib/runner.php';
+
+?>


### PR DESCRIPTION
Description:

- PR is to fix windows compatibility issues in running php-unit.
- The current repo works fine for mac, but not for windows.
- Handled the commands of scripts in composer json to a php file, as env variable setting is different for mac and windows. - - So, handled it generically to a php file (triggerTest.php).
- Similarly handled the system command execution based on OS for both win and mac /linux in runner.php.
- Fixed taskid conversion to int inside array pointer, as it passes string in windows.